### PR TITLE
feat: per-persona model support for swarm deliberation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,16 @@ ENGINE_PORT=8088
 ORACLE_TEMPERATURE=0.5          # 0=cautious, 1=imaginative
 ORACLE_TIMEOUT_SEC=180
 
+# ── Swarm persona models (optional) ──
+# Override the LLM model used for individual swarm personas during deliberation.
+# Each persona can use a different model suited to its lens. When unset, the
+# persona falls back to the main LLM_MODEL. Useful for running a reasoning
+# model on the Skeptic while keeping faster models on other personas.
+# SWARM_MODEL_STRATEGIST=qwen2.5:32b
+# SWARM_MODEL_ECONOMIST=qwen2.5:32b
+# SWARM_MODEL_NATURALIST=gemma3:12b
+# SWARM_MODEL_SKEPTIC=deepseek-r1:14b
+
 # ── Predictions ──
 HORIZONS=24h,week,month,year    # time horizons to forecast
 PREDICTIONS_PER_HORIZON=3

--- a/engine/config.py
+++ b/engine/config.py
@@ -80,6 +80,16 @@ class Config:
 
     # ── Swarm (a council of LLM personas deliberates each forecast) ──
     swarm_enabled: bool = field(default_factory=lambda: _b("SWARM_ENABLED", True))
+    swarm_persona_models: dict[str, str] = field(default_factory=lambda: {
+        name: model
+        for name, model in [
+            ("Strategist", os.environ.get("SWARM_MODEL_STRATEGIST", "")),
+            ("Economist", os.environ.get("SWARM_MODEL_ECONOMIST", "")),
+            ("Naturalist", os.environ.get("SWARM_MODEL_NATURALIST", "")),
+            ("Skeptic", os.environ.get("SWARM_MODEL_SKEPTIC", "")),
+        ]
+        if model
+    })
 
     def summary(self) -> dict:
         return {

--- a/engine/oracle.py
+++ b/engine/oracle.py
@@ -94,8 +94,8 @@ class Oracle:
     async def _chat(self, user: str) -> str:
         return await self._complete([{"role": "system", "content": SYSTEM}, {"role": "user", "content": user}], 1400)
 
-    async def _complete(self, messages: list[dict], max_tokens: int = 900) -> str:
-        body = {"model": self.model, "messages": messages, "temperature": CONFIG.temperature, "max_tokens": max_tokens}
+    async def _complete(self, messages: list[dict], max_tokens: int = 900, model: str | None = None) -> str:
+        body = {"model": model or self.model, "messages": messages, "temperature": CONFIG.temperature, "max_tokens": max_tokens}
         async with httpx.AsyncClient(verify=HTTPX_VERIFY, timeout=CONFIG.request_timeout) as c:
             r = await c.post(f"{self.base}/chat/completions", json=body,
                              headers={"Authorization": f"Bearer {self.key}"})

--- a/engine/swarm.py
+++ b/engine/swarm.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 
+from .config import CONFIG
 from .models import AgentView, Prediction, WorldBrief
 
 log = logging.getLogger("pythia.swarm")
@@ -50,8 +51,9 @@ def _persona_messages(name: str, lens: str, brief_text: str, preds: list[Predict
 async def _ask(oracle, name: str, lens: str, brief_text: str,
                preds: list[Prediction]) -> tuple[str, dict[int, tuple[float, str]]]:
     """Run one persona; return its {prediction_index: (probability, note)} map."""
+    persona_model = CONFIG.swarm_persona_models.get(name)
     try:
-        text = await oracle._complete(_persona_messages(name, lens, brief_text, preds), max_tokens=1300)
+        text = await oracle._complete(_persona_messages(name, lens, brief_text, preds), max_tokens=1300, model=persona_model)
     except Exception as e:  # noqa: BLE001
         log.warning("swarm persona %s failed: %s", name, e)
         return name, {}


### PR DESCRIPTION
## Summary

Allow each swarm persona (Strategist, Economist, Naturalist, Skeptic) to use a different Ollama model during forecast deliberation, configured via environment variables.

## Motivation

Each persona judges predictions through a fundamentally different lens. Different model architectures have different strengths that align naturally with these roles:

- A **reasoning model** (e.g. `deepseek-r1`) excels at the Skeptic's job — stress-testing assumptions, checking base rates, and playing devil's advocate via chain-of-thought reasoning
- A **larger general model** (e.g. `qwen2.5:32b`) brings deeper analytical capacity to the Strategist and Economist's geopolitical and macro-economic analysis
- A **solid mid-range model** (e.g. `gemma3:12b`) handles the Naturalist's disaster/weather/health pattern matching efficiently

Running all four on the same model means you're either over-provisioning for simple personas or under-provisioning for complex ones.

## Configuration

New optional environment variables in `.env`:

```bash
SWARM_MODEL_STRATEGIST=qwen2.5:32b
SWARM_MODEL_ECONOMIST=qwen2.5:32b
SWARM_MODEL_NATURALIST=gemma3:12b
SWARM_MODEL_SKEPTIC=deepseek-r1:14b
```

When unset, each persona falls back to the main `LLM_MODEL`, preserving existing behavior. Zero breaking changes.

## Changes

- **`engine/config.py`** — Add `swarm_persona_models` dict built from `SWARM_MODEL_*` env vars
- **`engine/oracle.py`** — Add optional `model` parameter to `_complete()` (2-line change)
- **`engine/swarm.py`** — Look up per-persona model and pass it through to `_complete()`
- **`.env.example`** — Document new env vars with suggested model mappings

## Design Notes

- Personas already run concurrently via `asyncio.gather`, so different-sized models just finish at different speeds — no architectural changes needed
- All models share the same Ollama endpoint (base URL, API key, timeout) — only the model name varies
- The dict comprehension in config filters out empty strings, so unset vars produce a clean empty dict and the fallback path is just `model or self.model`
