### PR TITLE
fix(oracle): stop silently dropping every forecast pass

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -84,6 +84,11 @@ class Config:
     # models burn ~1300 tokens (mostly hidden chain-of-thought) here, so keep generous
     # headroom or the JSON truncates mid-answer (see JUDGE_MAX_TOKENS).
     whatif_max_tokens: int = field(default_factory=lambda: _i("WHATIF_MAX_TOKENS", 2400))
+    # token budget for the main forecast pass. The prompt asks for
+    # PREDICTIONS_PER_HORIZON x len(HORIZONS) objects, each carrying statement +
+    # reasoning + location + coords, so the previous hardcoded 1400 truncated the
+    # JSON mid-array and _parse() silently returned zero predictions.
+    oracle_max_tokens: int = field(default_factory=lambda: _i("ORACLE_MAX_TOKENS", 6000))
 
     # ── Swarm (a council of LLM personas deliberates each forecast) ──
     swarm_enabled: bool = field(default_factory=lambda: _b("SWARM_ENABLED", True))

--- a/engine/oracle.py
+++ b/engine/oracle.py
@@ -96,7 +96,7 @@ class Oracle:
         return preds
 
     async def _chat(self, user: str) -> str:
-        return await self._complete([{"role": "system", "content": SYSTEM}, {"role": "user", "content": user}], 1400)
+        return await self._complete([{"role": "system", "content": SYSTEM}, {"role": "user", "content": user}], CONFIG.oracle_max_tokens)
 
     async def _complete(self, messages: list[dict], max_tokens: int = 900, model: str | None = None) -> str:
         body = {"model": model or self.model, "messages": messages, "temperature": CONFIG.temperature, "max_tokens": max_tokens}
@@ -245,9 +245,13 @@ class Oracle:
                 it = json.loads(chunk)
             except (ValueError, TypeError):
                 continue
-            pred = cls._clean_pred(it, brief_id)
-            if pred:
-                preds.append(pred)
+            # models frequently wrap the array in {"predictions": [...]} even when the
+            # prompt asks for a bare array; accept both shapes instead of dropping the pass.
+            items = it.get("predictions", []) if isinstance(it, dict) and isinstance(it.get("predictions"), list) else [it]
+            for item in items:
+                pred = cls._clean_pred(item, brief_id)
+                if pred:
+                    preds.append(pred)
         if not preds:
             log.warning("oracle: no predictions parsed from: %s", text[:200])
         return preds


### PR DESCRIPTION
Two independent bugs made `Oracle.forecast` return zero predictions on every run, with nothing but a `WARNING` in the log.

### 1. Hardcoded token budget truncates the JSON

`_chat` passed a literal `1400` to `_complete`, while the prompt asks for `PREDICTIONS_PER_HORIZON x len(HORIZONS)` objects — 12 under the default config — each carrying `statement` + `reasoning` + `location` + `lat`/`lng`. The response was cut mid-array, `_parse` raised, and the pass returned `[]`.

Replaced with a configurable `ORACLE_MAX_TOKENS` (default `6000`), following the same pattern already used for `JUDGE_MAX_TOKENS`, `WHATIF_MAX_TOKENS` and the swarm budgets — all of which already carry comments warning about exactly this truncation failure mode.

### 2. `_parse` drops wrapped prediction arrays

`_parse` assumed every decoded chunk was a bare prediction object. Models routinely answer with `{"predictions": [...]}` even when the prompt asks for a bare array — note that `what_if` explicitly requests that wrapped shape itself. Those chunks were silently discarded. Both shapes are now accepted.

### Evidence

Reproduced against a local Qwen3.6-MoE-35B-A3B via Ollama: **0/12 predictions parsed before, 12/12 after**, with no other change. Both fixes are provider-agnostic — the truncation is a function of prompt size, not of which model serves it.

### Notes

- No behaviour change when the model already returns a bare array within budget.
- `ORACLE_MAX_TOKENS` is env-overridable, so anyone on a tighter context can lower it.